### PR TITLE
BUG: Make Test for Number of Row Columns and Test Comment Match

### DIFF
--- a/test/portfolio.spec.js
+++ b/test/portfolio.spec.js
@@ -120,7 +120,7 @@ describe('The webpage', () => {
       });
 
       it('should exist at least 3 @marketing-columns', () => {
-        assert(columns.length === 3, 'Our `.row` element needs at least 3 column elements.');
+        assert(columns.length >= 3, 'Our `.row` element needs at least 3 column elements.');
       });
 
       it('should have an icon with the glyphicon icon class @marketing-columns', () => {


### PR DESCRIPTION
There is an issue in the test for the marketing columns. The documentation as well as the test assertion states that there should be "at least 3 columns" however the test checks for exactly 3 columns so the test fails if more than 3 columns exist. This change fixes the test by updating the check from `columns.length === 3` to `columns.length >= 3`.